### PR TITLE
Fixing future deprecation in Auth (see details)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - nodejs=14.15.1
   - twine
   - yarn=1.22.5
+  - pycurl


### PR DESCRIPTION
Starting in march 2021, the authentication through github's API must be done by passing the auth token through _headers_ and not through a GET parameter in the URL anymore.

https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/